### PR TITLE
Mention license in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "repository": "github:fabiospampinato/pikchr-wasm",
   "description": "A fast and small port of Pikchr to WASM.",
   "version": "2.0.0",
+  "license": "MIT",
   "type": "module",
   "sideEffects": false,
   "main": "dist/speed.js",


### PR DESCRIPTION
This solves some problems with automatic license checkers.